### PR TITLE
Rename image in models

### DIFF
--- a/models/Collection.model.js
+++ b/models/Collection.model.js
@@ -17,7 +17,7 @@ const collectionSchema = new Schema(
     description: {
       type: String
     },
-    image: {
+    imageUrl: {
       type: String,
       default:"No image"
     },

--- a/models/Item.model.js
+++ b/models/Item.model.js
@@ -15,7 +15,7 @@ const itemSchema = new Schema(
     description: {
       type: String,
     },
-    image: {
+    imageUrl: {
       type: String,
       default:"No image"
     },


### PR DESCRIPTION
Renames the "image" key in the Item and Collection models to "imageUrl". This way, the nomenclature is consistent with the User model and the whole body of functions for the cloudinary file upload (using "imageUrl" in multiple places")