### PR TITLE
Fix double comments, created item count for user

### DIFF
--- a/routes/item.routes.js
+++ b/routes/item.routes.js
@@ -10,7 +10,10 @@ const User = require('../models/User.model');
 router.post('/items', async (req, res, next) => {
 	try {
 		// Retrieve the item data from the request body
-		const { name, description, imageUrl, createdBy, categories, collections, commentTitle, comment, currentUser } = req.body;
+		const { name, description, imageUrl, createdBy, categories, collections, commentTitle, comment, currentUser } =
+			req.body;
+
+		console.log('Item created by: ', createdBy);
 
 		const categoryArray = await Category.find({
 			category: { $in: categories },
@@ -20,12 +23,9 @@ router.post('/items', async (req, res, next) => {
 			title: commentTitle,
 			body: comment,
 			user: createdBy,
-
 		});
 
 		const userCommentArray = [userComment._id];
-
-
 
 		// Do some validation on the input data
 		if (!name) {
@@ -33,23 +33,29 @@ router.post('/items', async (req, res, next) => {
 			return;
 		}
 
-
-//Create a free item (meaning not attached to a collection from the start)
-		if (collections === '') {
+		//Create a free item (meaning not attached to a collection from the start)
+		//if comment is an empty string, leave the comments array empty
+		if (collections === '' && comment === '') {
 			const newFreeItem = await Item.create({
 				name,
 				description,
 				imageUrl,
 				createdBy,
 				categories: categoryArray,
+				comments: [],
 			});
+
+			//update the users "items" array with the new item
+			await User.findByIdAndUpdate(createdBy, {
+				$push: { items: newFreeItem._id },
+			}).populate('items');
+
 			res.status(201).json({ item: newFreeItem });
 		}
 
+		//Create an item that is attached to a collection from the start
 
-//Create an item that is attached to a collection from the start
-
-let newItem;
+		let newItem;
 
 		if (imageUrl !== '') {
 			//if the user has chosen an image, use that image
@@ -60,7 +66,7 @@ let newItem;
 				createdBy,
 				categories: categoryArray,
 				collections,
-				comments: [userComment._id],
+				// comments: [userComment._id],
 			});
 		} else {
 			//if the user has not chosen an image, use the default image
@@ -70,32 +76,40 @@ let newItem;
 				createdBy,
 				categories: categoryArray,
 				collections,
-				comments: [userComment._id],
+				// comments: [userComment._id],
 			});
 		}
 
 		const populatedUserComment = await Comment.findById(userComment._id).populate('user');
 
+		//Update the item'S "comments" array with the comment
+		if (commentTitle !== '' && comment !== '') {
+			await Item.findByIdAndUpdate(newItem._id, { $push: { comments: populatedUserComment } }, { new: true }).populate(
+				'comments'
+			);
+		}
 
+		// Update the collections "items" array with the new item
+		await Collection.updateMany({ _id: { $in: collections } }, { $push: { items: newItem } }, { new: true }).populate(
+			'items'
+		);
 
-			//Update the item'S "comments" array with the comment
-			await Item.findByIdAndUpdate(newItem._id, { $push: { comments: populatedUserComment } }, { new: true }).populate('comments');
+		//update the users "items" array with the new item
+		await User.findByIdAndUpdate(createdBy, {
+			$push: { items: newItem._id },
+		}).populate('items');
 
-			// Update the collections "items" array with the new item
-			await Collection.updateMany({ _id: { $in: collections } }, { $push: { items: newItem } }, { new: true }).populate('items');
+		// and the users "comments" with the new comment
 
-			//update the users "items" array with the new item and the users "comments" with the new comment
-			await User.findByIdAndUpdate(createdBy, {
-				$push: { items: newItem._id }, $push: { comments: userComment },
-			}).populate('items').populate('comments');
+		await User.findByIdAndUpdate(createdBy, {
+			$push: { comments: userComment },
+		}).populate('comments');
 
-			//update the newly added item with the current Users ID in the item's "users" array
-			await Item.findByIdAndUpdate(newItem._id, { $push: { users: currentUser._id } }, { new: true }).populate('users');
+		//update the newly added item with the current Users ID in the item's "users" array
+		await Item.findByIdAndUpdate(newItem._id, { $push: { users: currentUser._id } }, { new: true }).populate('users');
 
-			// Send back a success response with the newly created item
-			res.status(201).json({ item: newItem });
-
-
+		// Send back a success response with the newly created item
+		res.status(201).json({ item: newItem });
 	} catch (error) {
 		console.error(error);
 		res.status(500).json({ message: 'Internal Server Error' });
@@ -106,7 +120,11 @@ let newItem;
 router.get('/items', async (req, res, next) => {
 	try {
 		// Retrieve all the items from the database
-		const items = await Item.find({}).populate('categories').populate('collections').populate('createdBy').populate('comments');
+		const items = await Item.find({})
+			.populate('categories')
+			.populate('collections')
+			.populate('createdBy')
+			.populate('comments');
 
 		// Send back a success response with the items
 		res.status(200).json({ items });
@@ -126,7 +144,12 @@ router.get('/items/:id', async (req, res, next) => {
 
 		// Retrieve the item details from the database
 
-		const item = await Item.findById(id).populate('categories').populate('collections').populate('createdBy').populate('comments').populate('users');
+		const item = await Item.findById(id)
+			.populate('categories')
+			.populate('collections')
+			.populate('createdBy')
+			.populate('comments')
+			.populate('users');
 
 		const itemComments = await Item.findById(id).populate('comments');
 
@@ -136,10 +159,6 @@ router.get('/items/:id', async (req, res, next) => {
 			const theComments = await Comment.findById(comment._id).populate('user');
 			populatedComments.push(theComments);
 		}
-
-
-
-
 
 		// Send back a success response with the item
 		res.status(200).json({ item: item, comments: populatedComments });
@@ -159,61 +178,62 @@ router.put('/items/:id/edit', async (req, res, next) => {
 			category: { $in: categories },
 		});
 
-// make an array of all this items comments
+		// make an array of all this items comments
 
 		const itemComments = await Item.findById(id).populate('comments');
 
-		console.log(itemComments.comments)
 
-		if( itemComments.comments.length === 0) {
-			const newComment =  await Comment.create({
+		if (itemComments.comments.length === 0) {
+			const newComment = await Comment.create({
 				title: commentTitle,
 				body: comment,
 				user: currentUserId,
 			});
 
-			console.log('comment created')
 
 			const item = await Item.findByIdAndUpdate(
 				id,
 				{ name, description, imageUrl, categories: categoryArray, $push: { comments: newComment } },
 				{ new: true }
-			);		res.status(200).json(item);
-
+			);
+			res.status(200).json(item);
 		} else {
-
 			//see if the users ID is in this specific item's "comments" array
 
 			async function updateItemWithComment(currentUserId, itemComments) {
 				let commentToUpdateId = null;
 
 				itemComments.comments.forEach((comment) => {
-				  if (comment.user._id.toString() === currentUserId) {
-					commentToUpdateId = comment._id;
-					return; // Exit the loop after finding the matching comment
-				  }
+					if (comment.user._id.toString() === currentUserId) {
+						commentToUpdateId = comment._id;
+						return; // Exit the loop after finding the matching comment
+					}
 				});
 
 				if (commentToUpdateId) {
-				  await Comment.findByIdAndUpdate(commentToUpdateId, {
-					title: commentTitle,
-					body: comment
-				  }, { new: true });
+					await Comment.findByIdAndUpdate(
+						commentToUpdateId,
+						{
+							title: commentTitle,
+							body: comment,
+						},
+						{ new: true }
+					);
 				}
 
 				const item = await Item.findByIdAndUpdate(
-				  id,
-				  { name, description, imageUrl, categories: categoryArray },
-				  { new: true }
+					id,
+					{ name, description, imageUrl, categories: categoryArray },
+					{ new: true }
 				);
 
 				return item;
-			  }
+			}
 
-			  const item = await updateItemWithComment(currentUserId, itemComments);
+			const item = await updateItemWithComment(currentUserId, itemComments);
 
-
-		res.status(200).json(item); }
+			res.status(200).json(item);
+		}
 	} catch (error) {
 		console.error(error);
 		res.status(500).json({ message: 'Internal Server Error' });
@@ -225,51 +245,40 @@ router.post('/items/:id', async (req, res, next) => {
 	const { id } = req.params;
 	const { createdBy, collection, currentUser } = req.body;
 
-
 	try {
-
 		//find the item in question
 
 		const itemInQuestion = await Item.findById(id).populate('comments');
 
 		async function deleteComment(currentUser, id, itemInQuestion) {
 			const commentToDelete = itemInQuestion.comments.find((comment) => {
-				console.log("This is the comment", comment)
-			  return comment.user == currentUser;
+				return comment.user == currentUser;
 			});
 
 			if (commentToDelete) {
-				console.log("Deleting the comment", commentToDelete)
-			  // Delete the comment from the database
-			  await Item.findByIdAndUpdate(id, { $pull: { comments: commentToDelete._id } }, { new: true });
-			  await User.findByIdAndUpdate(currentUser, { $pull: { comments: commentToDelete._id } }, { new: true });
+				console.log('Deleting the comment', commentToDelete);
+				// Delete the comment from the database
+				await Item.findByIdAndUpdate(id, { $pull: { comments: commentToDelete._id } }, { new: true });
+				await User.findByIdAndUpdate(currentUser, { $pull: { comments: commentToDelete._id } }, { new: true });
 			} else {
-					console.log("No comment to delete")
-
-		  }
+				console.log('No comment to delete');
+			}
 		}
 
-		  deleteComment(currentUser, id, itemInQuestion);
-
-
+		deleteComment(currentUser, id, itemInQuestion);
 
 		//Take the item out of the user's items array
-	// Delete the item from the database
-	await User.findByIdAndUpdate(currentUser, { $pull: { items: id } });
-	console.log("Pulled the item from the user's items array")
+		// Delete the item from the database
+		await User.findByIdAndUpdate(currentUser, { $pull: { items: id } });
 
-	//pull the user from items user array
+		//pull the user from items user array
 
-	await Item.findByIdAndUpdate(id, { $pull: { users: currentUser } });
+		await Item.findByIdAndUpdate(id, { $pull: { users: currentUser } });
 
-	// Delete item from the current collection
-	await Collection.findByIdAndUpdate(collection, { $pull: { items: id } });
-	console.log("Pulled the item from the collection's items array")
+		// Delete item from the current collection
+		await Collection.findByIdAndUpdate(collection, { $pull: { items: id } });
 
-
-	await Item.findByIdAndUpdate(id, { $pull: { collections: collection }  }, { new: true });
-	console.log("Pulled the collection from the item's collections array")
-
+		await Item.findByIdAndUpdate(id, { $pull: { collections: collection } }, { new: true });
 
 		res.status(200).json({ message: 'Item deleted successfully' });
 	} catch (error) {

--- a/routes/item.routes.js
+++ b/routes/item.routes.js
@@ -15,6 +15,8 @@ router.post('/items', async (req, res, next) => {
 
 		console.log('Item created by: ', createdBy);
 
+		console.log('Comment made on this item:', comment);
+
 		const categoryArray = await Category.find({
 			category: { $in: categories },
 		});
@@ -33,25 +35,28 @@ router.post('/items', async (req, res, next) => {
 			return;
 		}
 
-		//Create a free item (meaning not attached to a collection from the start)
-		//if comment is an empty string, leave the comments array empty
-		if (collections === '' && comment === '') {
-			const newFreeItem = await Item.create({
-				name,
-				description,
-				imageUrl,
-				createdBy,
-				categories: categoryArray,
-				comments: [],
-			});
 
-			//update the users "items" array with the new item
-			await User.findByIdAndUpdate(createdBy, {
-				$push: { items: newFreeItem._id },
-			}).populate('items');
 
-			res.status(201).json({ item: newFreeItem });
-		}
+		// //Create a free item (meaning not attached to a collection from the start)
+		// //if comment is an empty string, leave the comments array empty
+		// if (collections === '' && comment === '') {
+		// 	const newFreeItem = await Item.create({
+		// 		name,
+		// 		description,
+		// 		imageUrl,
+		// 		createdBy,
+		// 		categories: categoryArray,
+		// 		// comments: [],
+		// 	});
+
+		// 	//update the users "items" array with the new item
+		// 	await User.findByIdAndUpdate(createdBy, {
+		// 		$push: { items: newFreeItem._id},
+		// 	}).populate('items');
+
+
+		// 	res.status(201).json({ item: newFreeItem  });
+		// }
 
 		//Create an item that is attached to a collection from the start
 
@@ -83,7 +88,7 @@ router.post('/items', async (req, res, next) => {
 		const populatedUserComment = await Comment.findById(userComment._id).populate('user');
 
 		//Update the item'S "comments" array with the comment
-		if (commentTitle !== '' && comment !== '') {
+		if (comment !== '') {
 			await Item.findByIdAndUpdate(newItem._id, { $push: { comments: populatedUserComment } }, { new: true }).populate(
 				'comments'
 			);
@@ -99,14 +104,11 @@ router.post('/items', async (req, res, next) => {
 			$push: { items: newItem._id, comments: userComment._id },
 		}).populate('items').populate('comments');
 
-		// // and the users "comments" with the new comment
 
-		// await User.findByIdAndUpdate(createdBy, {
-		// 	$push: { comments: userComment },
-		// }).populate('comments');
 
 		//update the newly added item with the current Users ID in the item's "users" array
 		await Item.findByIdAndUpdate(newItem._id, { $push: { users: currentUser._id } }, { new: true }).populate('users');
+
 
 		// Send back a success response with the newly created item
 		res.status(201).json({ item: newItem });

--- a/routes/item.routes.js
+++ b/routes/item.routes.js
@@ -96,14 +96,14 @@ router.post('/items', async (req, res, next) => {
 
 		//update the users "items" array with the new item
 		await User.findByIdAndUpdate(createdBy, {
-			$push: { items: newItem._id },
-		}).populate('items');
+			$push: { items: newItem._id, comments: userComment._id },
+		}).populate('items').populate('comments');
 
-		// and the users "comments" with the new comment
+		// // and the users "comments" with the new comment
 
-		await User.findByIdAndUpdate(createdBy, {
-			$push: { comments: userComment },
-		}).populate('comments');
+		// await User.findByIdAndUpdate(createdBy, {
+		// 	$push: { comments: userComment },
+		// }).populate('comments');
 
 		//update the newly added item with the current Users ID in the item's "users" array
 		await Item.findByIdAndUpdate(newItem._id, { $push: { users: currentUser._id } }, { new: true }).populate('users');


### PR DESCRIPTION
This PR fixes two things:

**Duplicate Items showing up**
We had the issue that when creating new items (no matter if "free" or connected to a collection) that user comments would show up, and to add insult to injury, they'd show up **twice**. Either for the free or non-free item it was even worse - not writing a comment upon item creation would just create a "blank" comment with the headline "Author says": ""...which was dumb.
Editing the item to leave a comment would also just ADD another comment to the existing one.

So I checked the code, and it was all a back end issue - meaning that I had to put in a condition to check if the comment string was empty on items that actually NEED a comment (or could have one to begin with), and if it's not an empty string, we add the comment.

Then I had to undo some nonsense I wrote earlier which made it so that the User's ID who created the comment (be it empty or not) would be pushed into the comments array no matter what. That was quatsch, so I deleted that line.

Now comments will show up when they are supposed to, and since I only changed the backend code, the new front end code should hopefully work just fine with it.

**Created Item Count in Profile not being updated**
I updated the code that was a neat oneliner which upon item creation pushed a new item and a new comment on that item directly into the respective arrays for the User who created both. Populated it right away too. That did not work - you can't have two "$push" statements in one mongoose command. But you can just chain the objects you wanna update with a comma...
So it works now.

Thankfully you're not connected to my local DB cause all the new items called "123123öoujhpbiu12elbihb" would drive you nuts.